### PR TITLE
fix: Stacks deployed with CDK versions earlier than 1.93.0 cause an error, and are not detected correctly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -148,10 +148,21 @@ async function findV1Stacks(
       body = YAML.parse(getTemplateResponse.TemplateBody);
     }
     if (body.Resources.CDKMetadata) {
-      const buf = Buffer.from(body.Resources.CDKMetadata.Properties.Analytics.split(':').splice(2)[0], 'base64');
-      const analyticsString = zlib.gunzipSync(buf).toString();
-      const majorVersion = analyticsString.slice(0, 1);
-      if (majorVersion === '1') {
+      let stackUsedV1 = false;
+      if (body.Resources.CDKMetadata.Properties?.Analytics) {
+        var buf = Buffer.from(body.Resources.CDKMetadata.Properties.Analytics.split(':').splice(2)[0], 'base64');
+        if (!buf) {
+        }
+        const analyticsString = zlib.gunzipSync(buf).toString();
+        stackUsedV1 = analyticsString.slice(0, 1) === '1';
+      }
+
+      // Before versions 1.93.0 and 2.0.0-alpha.10, the CDKMetadata resource had a different format.
+      if (body.Resources.CDKMetadata.Properties?.Modules) {
+        stackUsedV1 = body.Resources.CDKMetadata.Properties.Modules.includes('@aws-cdk/core');
+      }
+
+      if (stackUsedV1) {
         stacks.push(`name: ${stack.StackName} | id: ${stack.StackId}`);
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,9 +150,7 @@ async function findV1Stacks(
     if (body.Resources.CDKMetadata) {
       let stackUsedV1 = false;
       if (body.Resources.CDKMetadata.Properties?.Analytics) {
-        var buf = Buffer.from(body.Resources.CDKMetadata.Properties.Analytics.split(':').splice(2)[0], 'base64');
-        if (!buf) {
-        }
+        const buf = Buffer.from(body.Resources.CDKMetadata.Properties.Analytics.split(':').splice(2)[0], 'base64');
         const analyticsString = zlib.gunzipSync(buf).toString();
         stackUsedV1 = analyticsString.slice(0, 1) === '1';
       }


### PR DESCRIPTION

…
Fixes #8 