### PR TITLE
fix: continue processing stacks after an error has occurred

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,11 @@ async function findV1Stacks(
       StackName: stack.StackName,
     }).promise().catch((error) => console.error(`${region}: Failed to get template for stack: ${stack.StackName}. Error: ${error}`)) as any;
 
+    if (!getTemplateResponse.TemplateBody) {
+      console.error(`${region}: Failed to parse template for stack: ${stack.StackName}. No template body was present`);
+      continue;
+    }
+
     var body;
     var jsonErr;
     try {
@@ -152,6 +157,7 @@ async function findV1Stacks(
         body = YAML.parse(getTemplateResponse.TemplateBody);
       } catch (yamlErr) {
         console.error(`${region}: Failed to parse template for stack: ${stack.StackName}. \nJSON Parse Error: ${jsonErr} \nYAML Parse Error: ${yamlErr}`);
+        continue;
       }
     }
 


### PR DESCRIPTION
Fixes: #273

When processing accounts with 1000's of CF stacks, it's really annoying for the whole process to fail part way through.

Also if a stack is (stuck) in 'REVIEW_IN_PROGRESS' then there will be no `TemplateBody`.