### PR TITLE
chore: disable SDKv2 warning message

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,7 @@
 import { find } from './index';
 
+process.env.AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE = '1';
+
 find().catch(e => {
   console.log(e);
   process.exit(1);


### PR DESCRIPTION
The JS SDKv2 is starting to emit a warning message to scare people away:

```
(node:25530) NOTE: We are formalizing our plans to enter AWS SDK for JavaScript (v2) into maintenance mode in 2023.

Please migrate your code to use AWS SDK for JavaScript (v3).
For more information, check the migration guide at https://a.co/7PzMCcy
(Use `node --trace-warnings ...` to show where the warning was created)
```

We are aware, and will migrate eventually. In the mean time, let's not bother our users with this warning.
