### PR TITLE
feat: print versions, recognize monocdk, recognize v0, add missing regions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -166,18 +166,16 @@ async function findV1Stacks(
         const buf = Buffer.from(body.Resources.CDKMetadata.Properties.Analytics.split(':').splice(2)[0], 'base64');
         const analyticsString = zlib.gunzipSync(buf).toString();
         const constructInfo = decodePrefixEncodedString(analyticsString);
-        const stackConstruct = constructInfo.find(x => x.endsWith('@aws-cdk/core.Stack'));
+        const stackConstruct = constructInfo.find(x => x.endsWith('@aws-cdk/core.Stack') || x.endsWith('monocdk.Stack'));
         if (stackConstruct) {
           stackVersion = stackConstruct.split('!')[0];
         }
       }
 
       // Before versions 1.93.0 and 2.0.0-alpha.10, the CDKMetadata resource had a different format.
-      //
-      // Anything that uses this format is definitely too old.
       if (body.Resources.CDKMetadata.Properties?.Modules) {
         const modules = body.Resources.CDKMetadata.Properties.Modules.split(',') as string[];
-        const coreModule = modules.find(m => m.startsWith('@aws-cdk/core='));
+        const coreModule = modules.find(m => m.startsWith('@aws-cdk/core=') || m.startsWith('monocdk='));
         if (coreModule) {
           stackVersion = coreModule.split('=')[1];
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,9 +88,9 @@ export async function find() {
   console.log('');
 
   if (stacks.length === 0) {
-    console.log('No AWS CDK V1 stacks found');
+    console.log('No unsupported AWS CDK stacks found');
   } else {
-    console.log(`Found ${stacks.length} AWS CDK V1 stacks:`);
+    console.log(`Found ${stacks.length} stacks produced by an unsupported AWS CDK version:`);
     console.log('');
     for (const stack of stacks) {
       console.log(stack);

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,7 @@ async function findV1Stacks(
         const buf = Buffer.from(body.Resources.CDKMetadata.Properties.Analytics.split(':').splice(2)[0], 'base64');
         const analyticsString = zlib.gunzipSync(buf).toString();
         const constructInfo = decodePrefixEncodedString(analyticsString);
+        // Strings look like `<version>!<library>.<construct>`
         const stackConstruct = constructInfo.find(x => x.endsWith('@aws-cdk/core.Stack') || x.endsWith('monocdk.Stack'));
         if (stackConstruct) {
           stackVersion = stackConstruct.split('!')[0];
@@ -175,6 +176,7 @@ async function findV1Stacks(
       // Before versions 1.93.0 and 2.0.0-alpha.10, the CDKMetadata resource had a different format.
       if (body.Resources.CDKMetadata.Properties?.Modules) {
         const modules = body.Resources.CDKMetadata.Properties.Modules.split(',') as string[];
+        // Strings look like `<library>=<version>`
         const coreModule = modules.find(m => m.startsWith('@aws-cdk/core=') || m.startsWith('monocdk='));
         if (coreModule) {
           stackVersion = coreModule.split('=')[1];


### PR DESCRIPTION
Print the found version for each stack. Make sure that we also include monocdk and V0 stacks (there still are some people out there with V0 stacks), but we exclude `0.0.0` stacks which are just integ test stacks.

Example of new output:

```
Found 12 AWS CDK V1 stacks:

name: TestDockerAssetsStack | version: 1.119.0 | id: arn:aws:cloudformation:eu-west-1:111111:stack/TestDockerAssetsStack/1d5694e5-7b7b-4d2c-8d56-b267ab489768
name: TestRollbackStack | version: 1.119.0 | id: arn:aws:cloudformation:eu-west-1:111111:stack/TestRollbackStack/1d5694e5-7b7b-4d2c-8d56-b267ab489768
name: KesselRunStack | version: 1.148.0 | id: arn:aws:cloudformation:eu-central-1:111111:stack/KesselRunStack/1d5694e5-7b7b-4d2c-8d56-b267ab489768
```

Also adds new AWS Regions that were added since this script was originally written:   

```
  'me-central-1', // Middle East (UAE)
  'eu-central-2', // Europe (Zurich)
  'ap-south-2', // Asia Pacific (Hyderabad)
  'ap-southeast-4', // Asia Pacific (Melbourne)
```
