### PR TITLE
fix: treat all monocdk constructs as v1

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -177,7 +177,7 @@ async function findV1Stacks(
           const analyticsString = zlib.gunzipSync(buf).toString();
           const constructInfo = decodePrefixEncodedString(analyticsString);
           // Strings look like `<version>!<library>.<construct>`
-          const stackConstruct = constructInfo.find(x => x.endsWith('@aws-cdk/core.Stack') || x.endsWith('monocdk.Stack'));
+          const stackConstruct = constructInfo.find(x => x.endsWith('@aws-cdk/core.Stack') || x.endsWith('monocdk.Stack') || x.includes('!monocdk.') );
           if (stackConstruct) {
             stackVersion = stackConstruct.split('!')[0];
           }


### PR DESCRIPTION
`monocdk` is always v1.
So we should treat anything that uses `monocdk` as a v1 stack.

Fixes #345